### PR TITLE
remove prints

### DIFF
--- a/BOF/PetitPotam/SOURCE/PetitPotam.c
+++ b/BOF/PetitPotam/SOURCE/PetitPotam.c
@@ -1,3 +1,8 @@
+/*
+PetitPotam exploit by Cneelis @Outflank
+Based on original code by @topotam77
+*/
+
 #include <windows.h>
 
 #include "PetitPotam.h"
@@ -153,9 +158,6 @@ VOID go(IN PCHAR Args, IN ULONG Length) {
 		BeaconPrintf(CALLBACK_ERROR, "Missing arguments");
 		return;
 	}
-
-	BeaconPrintToStreamW(L"[>] PetitPotam exploit by Cneelis @Outflank\n");
-	BeaconPrintToStreamW(L"[>] Based on original code by @topotam77\n\n");
 
 	MSVCRT$wcscat_s(wcRPCTarget, _countof(wcRPCTarget), lpwTarget);
 	rStatus = CreateBindingHandle(wcRPCTarget, &bHandle);

--- a/Other/PetitPotam/SOURCE/PetitPotam/ReflectiveDll.c
+++ b/Other/PetitPotam/SOURCE/PetitPotam/ReflectiveDll.c
@@ -1,3 +1,8 @@
+/*
+PetitPotam exploit by Cneelis @Outflank
+Based on original code by @topotam77
+*/
+
 #undef  _UNICODE
 #define _UNICODE
 #undef  UNICODE
@@ -118,8 +123,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved) {
 			}
 
 			szArglist = CommandLineToArgvW(lpwParams, &nArgs);
-			wprintf(L"[>] PetitPotam exploit by Cneelis @Outflank\n");
-			wprintf(L"[>] Based on original code by @topotam77\n\n");
 			if (nArgs < 2) {
 				Usage(L"PetitPotam");
 				goto CleanUp;


### PR DESCRIPTION
I've moved prints (that would execute on the CPU of target) to comments in top of file.
Alternative would be to embed 'banner like' lines in scripting.